### PR TITLE
Fixed error in NEB report of unconverged directories

### DIFF
--- a/jasp/jasp_neb.py
+++ b/jasp/jasp_neb.py
@@ -77,11 +77,10 @@ def get_neb(self, npi=1):
                 f.close()
                 return False
 
-            converged = [subdir_converged('0{0}/OUTCAR'.format(i))
-                         for i in range(1,len(self.neb_images)-1)]
+            converged = subdir_converged('0{0}/OUTCAR'.format(i))
 
-            if False in converged:
-                print '0{0} does not appear converged'.format(converged.index(False))
+            if not converged:
+                print '0{0} does not appear converged'.format(i)
 
     # make sure no keywords have changed
     if not ((self.float_params == self.old_float_params) and


### PR DESCRIPTION
Small error when attempting to rerun NEB calculations. Previous error message always output that '00 does not appear converged'