### PR TITLE
Fixed rounding issue in get_dipole_moment for certain cases

### DIFF
--- a/jasp/jasprc.py
+++ b/jasp/jasprc.py
@@ -23,7 +23,7 @@ import os
 
 # default settings
 JASPRC = {'vasp.executable.serial':
-          '/opt/kitchingroup/vasp-5.3.5/bin/vasp-vtst-serial-beef',
+          '/opt/kitchingroup/vasp-5.3.5/bin/vasp-vtst-serial-beef-vaspsol',
           'vasp.executable.parallel':
           '/opt/kitchingroup/vasp-5.3.5/bin/vasp-vtst-parallel-beef-vaspsol',
           'mode': 'queue',  # other value is 'run'

--- a/jasp/jasprc.py
+++ b/jasp/jasprc.py
@@ -23,7 +23,7 @@ import os
 
 # default settings
 JASPRC = {'vasp.executable.serial':
-          '/opt/kitchingroup/vasp-5.3.5/bin/vasp-vtst-serial-beef-vaspsol',
+          '/opt/kitchingroup/vasp-5.3.5/bin/vasp-vtst-serial-beef',
           'vasp.executable.parallel':
           '/opt/kitchingroup/vasp-5.3.5/bin/vasp-vtst-parallel-beef-vaspsol',
           'mode': 'queue',  # other value is 'run'

--- a/jasp/volumetric_data.py
+++ b/jasp/volumetric_data.py
@@ -21,13 +21,11 @@ def get_volumetric_data(self, filename='CHG', **kwargs):
     data = np.array(vd.chg)
     n0, n1, n2 = data[0].shape
 
-    s0 = 1.0 / n0
-    s1 = 1.0 / n1
-    s2 = 1.0 / n2
+    s0 = np.linspace(0, 1, num=n0, endpoint=False)
+    s1 = np.linspace(0, 1, num=n1, endpoint=False)
+    s2 = np.linspace(0, 1, num=n2, endpoint=False)
 
-    X, Y, Z = np.mgrid[0.0:1.0:s0,
-                       0.0:1.0:s1,
-                       0.0:1.0:s2]
+    Y, X, Z = np.meshgrid(s0, s1, s2)
 
     C = np.column_stack([X.ravel(),
                          Y.ravel(),


### PR DESCRIPTION
There was a minor error where np.mgrid would occasionally produce a differently shaped array, potentially due to rounding errors in the s0, s1, and s2 fractions for larger arrays.

This formulation always results in arrays of the correct shape.