### PR TITLE
Minor edit to be able to read charge density from CHGCAR

### DIFF
--- a/jasp/volumetric_data.py
+++ b/jasp/volumetric_data.py
@@ -42,18 +42,19 @@ def get_volumetric_data(self, filename='CHG', **kwargs):
     return x, y, z, data
 
 
-def get_charge_density(self, spin=0):
+def get_charge_density(self, spin=0, filename='CHG'):
     """Returns x, y, and z coordinate and charge density arrays.
+    Supported file formats: CHG, CHGCAR
 
     :param int spin:
     :returns: x, y, z, charge density arrays
     :rtype: 3-d numpy arrays
 
-    Relies on :func:`ase.calculators.vasp.VaspChargeDensity`.
+    Relies on :func:`ase.calculators.vasp.VaspChargeDensity`.    
     """
 
 
-    x, y, z, data = get_volumetric_data(self, filename='CHG')
+    x, y, z, data = get_volumetric_data(self, filename=filename)
     return x, y, z, data[spin]
 
 Vasp.get_charge_density = get_charge_density

--- a/jasp/volumetric_data.py
+++ b/jasp/volumetric_data.py
@@ -50,9 +50,8 @@ def get_charge_density(self, spin=0, filename='CHG'):
     :returns: x, y, z, charge density arrays
     :rtype: 3-d numpy arrays
 
-    Relies on :func:`ase.calculators.vasp.VaspChargeDensity`.    
+    Relies on :func:`ase.calculators.vasp.VaspChargeDensity`.
     """
-
 
     x, y, z, data = get_volumetric_data(self, filename=filename)
     return x, y, z, data[spin]


### PR DESCRIPTION
Sometimes we might want to get the charge density from the CHGCAR file, e.g. relax calculations where the CHG file contains the charge densities of every step.