### PR TITLE
Error in restarting unsubmitted jobs

### DIFF
--- a/jasp/jasp.py
+++ b/jasp/jasp.py
@@ -217,9 +217,13 @@ def Jasp(debug=None,
 
         if atoms is not None:
             import ase.io
-            atoms0 = ase.io.read('POSCAR')
-            compatible_atoms_p(atoms0, atoms)
-            atoms.calc = calc
+            try:
+                atoms0 = ase.io.read('POSCAR')
+                compatible_atoms_p(atoms0, atoms)
+                atoms.calc = calc
+            except IOError:
+                # no POSCAR found
+                pass
         else:
             import ase.io
             try:

--- a/jasp/jasp.py
+++ b/jasp/jasp.py
@@ -216,7 +216,9 @@ def Jasp(debug=None,
             pass
 
         if atoms is not None:
-            compatible_atoms_p(calc.get_atoms(), atoms)
+            import ase.io
+            atoms0 = ase.io.read('POSCAR')
+            compatible_atoms_p(atoms0, atoms)
             atoms.calc = calc
         else:
             import ase.io


### PR DESCRIPTION
This code is causing restart errors for calculations which failed to enter the queue on the first attempt.

The calculator has no atoms object at this point in the code, so calc.get_atoms() is 'None' which results in the following error:
``` javascript
Traceback (most recent call last):
  File "<stdin>", line 35, in <module>
  File "/home-research/jboes/boes-python/jasp/jasp/jasp.py", line 484, in __enter__
    calc = Jasp(**self.kwargs)
  File "/home-research/jboes/boes-python/jasp/jasp/jasp.py", line 218, in Jasp
    print calc.get_atoms()
  File "/home-research/jboes/boes-python/ase/ase/calculators/vasp.py", line 697, in get_atoms
    atoms = self.atoms.copy()
AttributeError: 'NoneType' object has no attribute 'copy'
```

Here is a potential solution which constructs the existing atoms object directly from the POTCAR file, if it exists.