### PR TITLE
Important fix for get_required_memory()

### DIFF
--- a/jasp/jasp_extensions.py
+++ b/jasp/jasp_extensions.py
@@ -1266,13 +1266,17 @@ def get_required_memory(self):
             self.write_kpoints()
             self.write_sort_file()
 
+            # Need to pass a function to Timer for delayed execution
+            def kill():
+                process.kill()
+
             # We only need the memory estimate, so we can greatly
             # accelerate the process by terminating after we have it
             process = Popen(JASPRC['vasp.executable.serial'],
                             stdout=PIPE)
 
             from threading import Timer
-            timer = Timer(15.0, process.kill())
+            timer = Timer(20.0, kill)
             timer.start()
             while True:
                 if timer.is_alive():
@@ -1281,6 +1285,8 @@ def get_required_memory(self):
                         timer.cancel()
                         process.terminate()
                         break
+                    else:
+                        time.sleep(0.1)
                 else:
                     raise RuntimeError('Memory estimate timed out')
 

--- a/jasp/jasp_neb.py
+++ b/jasp/jasp_neb.py
@@ -328,7 +328,7 @@ def read_neb_calculator():
 
     images = []
     log.debug('calc.int_params[images] = %i', calc.int_params['images'])
-    for i in range(calc.int_params['images'] + 2):
+    for i in range(calc.int_params['images']):
         log.debug('reading neb calculator: 0%i', i)
         cwd = os.getcwd()
 
@@ -360,7 +360,7 @@ def read_neb_calculator():
     f = open('00/energy')
     calc.neb_initial_energy = float(f.readline().strip())
     f.close()
-    f = open('{0}/energy'.format(str(len(images) - 1)).zfill(2))
+    f = open('{0}/energy'.format(str(len(images) - 1).zfill(2)))
     calc.neb_final_energy = float(f.readline().strip())
     f.close()
 


### PR DESCRIPTION
The Timer function doesn't seem to work on a delay unless you pass a function to it.

Minor fixes to NEB to reflect how 'images' tag is implemented in the documentation https://github.com/jkitchin/jasp/blob/master/jasp/jasp_neb.py#L27.