### PR TITLE
new bader utils

### DIFF
--- a/jasp/jasp_atoms.py
+++ b/jasp/jasp_atoms.py
@@ -4,7 +4,8 @@ from ase import Atom, Atoms
 import numpy as np
 import pickle
 import textwrap
-
+import os
+from POTCAR import get_ZVAL
 
 def atoms_equal(self, other):
     '''Check if this :class:`ase.Atoms` object is identical to
@@ -84,6 +85,92 @@ def new_repr(self):
     return textwrap.fill(s, width=70, subsequent_indent=' '*6)
 
 Atoms.__repr__ = new_repr
+
+def attach_charges(self, fileobj='ACF.dat', displacement=1e-4):
+    '''
+    Attach the charges from the fileobj to the Atoms.
+    This is a modified version of the attach_charges function in
+    ase.io.bader to work better with VASP.
+    Does not require the atom positions to be in Bohr and references
+    the charge to the ZVAL in the POTCAR
+    '''
+    
+    calc = self.get_calculator()
+
+    # Get the sorting and resorting lists
+    sort = calc.sort
+    resort = calc.resort    
+    
+    if isinstance(fileobj, str):
+        fileobj = open(fileobj)
+        f_open = True
+                
+    # First get a dictionary of ZVALS from the pseudopotentials
+    LOP = calc.get_pseudopotentials()
+    ppp = os.environ['VASP_PP_PATH']
+    
+    zval = {}
+    for sym, ppath, hash in LOP:
+        fullpath = ppp + ppath
+        z = get_ZVAL(fullpath)
+        zval[sym] = z
+
+    
+    # Get sorted symbols and positions according to POSCAR and ACF.dat
+    symbols = np.array(self.get_chemical_symbols())[sort]
+    positions = self.get_positions()[sort]
+
+    
+    charges = []
+    sep = '---------------'
+    i = 0 # Counter for the lines
+    k = 0 # Counter of sep
+    assume6columns = False
+    for line in fileobj:
+        if line[0] == '\n': # check if there is an empty line in the 
+            i -= 1          # head of ACF.dat file
+        if i == 0:
+            headings = line
+            if 'BADER' in headings.split():
+                j = headings.split().index('BADER')
+            elif 'CHARGE' in headings.split():
+                j = headings.split().index('CHARGE')
+            else:
+                print('Can\'t find keyword "BADER" or "CHARGE".' \
+                +' Assuming the ACF.dat file has 6 columns.')
+                j = 4
+                assume6columns = True
+        if sep in line: # Stop at last seperator line
+            if k == 1:
+                break
+            k += 1
+        if not i > 1:
+            pass
+        else:
+            words = line.split()
+            if assume6columns is True:
+                if len(words) != 6:
+                    raise IOError('Number of columns in ACF file incorrect!\n'
+                                  'Check that Bader program version >= 0.25')
+                                
+            sym = symbols[int(words[0]) - 1]
+            charges.append(zval[sym] - float(words[j]))
+            
+            if displacement is not None:
+                # check if the atom positions match
+                xyz = np.array([float(w) for w in words[1:4]])
+                assert np.linalg.norm(positions[int(words[0]) - 1] - xyz) < displacement
+        i += 1
+
+    if f_open:
+        fileobj.close()
+
+    # Now attach the resorted charges to the atom
+    charges = np.array(charges)[resort]
+    for atom in self:
+        atom.charge = charges[atom.index]
+        
+Atoms.attach_charges = attach_charges
 
 if __name__ == '__main__':
     from ase.data.molecules import molecule

--- a/jasp/jasp_extensions.py
+++ b/jasp/jasp_extensions.py
@@ -1363,9 +1363,8 @@ def bader(self, cmd=None, ref=False, verbose=False, overwrite=False):
     out, err = p.communicate()
     if out == '' or err != '':
         raise Exception('Cannot perform Bader:\n\n{0}'.format(err))
-    else:
-        if verbose:
-            print('Bader completed for {0}'.format(self.vaspdir))
+    elif verbose:
+        print('Bader completed for {0}'.format(self.vaspdir))
 
 Vasp.bader = bader
 

--- a/jasp/jasp_extensions.py
+++ b/jasp/jasp_extensions.py
@@ -1318,3 +1318,54 @@ def get_required_memory(self):
     return memory
 
 Vasp.get_required_memory = get_required_memory
+
+def chgsum(self):
+    '''
+    Uses the chgsum.pl utility to sum over the AECCAR0 and AECCAR2 files
+    '''
+    cmdlist = ['chgsum.pl', 'AECCAR0', 'AECCAR2']
+    p = Popen(cmdlist, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    out, err = p.communicate()
+    if out == '' or err != '':
+        raise Exception('Cannot perform chgsum:\n\n{0}'.format(err))
+
+Vasp.chgsum = chgsum
+    
+def bader(self, cmd=None, ref=False, verbose=False, overwrite=False):
+
+    '''
+    Performs bader analysis for a calculation
+    
+    Follows defaults unless full shell command is specified
+
+    Does not overwrite existing files if overwrite=False
+    If ref = True, tries to reference the charge density to
+    the sum of AECCAR0 and AECCAR2
+
+    Requires the bader.pl (and chgsum.pl) script to be in the system PATH
+    '''
+
+    if 'ACF.dat' in os.listdir('./') and not overwrite:
+        return
+    
+    if cmd is None:
+        if ref:
+            self.chgsum()
+            cmdlist = ['bader', 'CHGCAR', '-ref', 'CHGCAR_sum']
+        else:
+            cmdlist = ['bader', 'CHGCAR']
+    elif type(cmd) is str:
+        cmdlist = cmd.split()
+    elif type(cmd) is list:
+        cmdlist = cmd
+        
+    p = Popen(cmdlist, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    out, err = p.communicate()
+    if out == '' or err != '':
+        raise Exception('Cannot perform Bader:\n\n{0}'.format(err))
+    else:
+        if verbose:
+            print('Bader completed for {0}'.format(self.vaspdir))
+
+Vasp.bader = bader
+


### PR DESCRIPTION
This patch contains new utilities for bader analysis.

1. Fixes the attach_charges function in ase.io bader
    - references the charge to the ZVAL in the POTCAR
    - does not require conversions to Bohr
    - is convenient for the jasp workflows

2. Also contains calc.chgsum() and calc.bader() as wrappers to call shell functions inside the context manager.

An example:

```python
from jasp import *
from ase.structure import molecule
atoms = molecule('H2O')
atoms.center(vacuum=6)

with jasp('tests/molecules/h2o-bader',
          xc='PBE',
          encut=350,
          laechg=True,
          atoms=atoms) as calc:
    calc.calculate()
    calc.bader(ref=True, overwrite=True)
    atoms.attach_charges('ACF.dat')
    for atom in atoms:
        print('|{0} | {1} |'.format(atom.symbol, atom.charge))
```

```
: |O | -1.2326 |
: |H | 0.6161 |
: |H | 0.6165 |
```