### PR TITLE
revert to calc.int_params['images'] + 2 in read_neb_calculator() and small change to default setting of functional

### DIFF
--- a/jasp/jasp_neb.py
+++ b/jasp/jasp_neb.py
@@ -323,12 +323,16 @@ def read_neb_calculator():
     calc.read_kpoints()
 
     # set default functional
+    # if both gga and xc are not specified
     if calc.string_params['gga'] is None:
-        calc.input_params['xc'] = 'PBE'
+        if calc.input_params['xc'] is None:
+            calc.input_params['xc'] = 'PBE'
 
     images = []
     log.debug('calc.int_params[images] = %i', calc.int_params['images'])
-    for i in range(calc.int_params['images']):
+    # Add 2 to IMAGES flag from INCAR to get
+    # first and last images
+    for i in range(calc.int_params['images'] + 2):
         log.debug('reading neb calculator: 0%i', i)
         cwd = os.getcwd()
 


### PR DESCRIPTION
This reverts a minor change https://github.com/jkitchin/jasp/commit/b59a7cb63cb59eb1fc57b899e0004a333cb68691#diff-a37babcd61371065b74d33adfc95cc58L331 to get NEBs to work again.

The pull request fixes an issue with the old behavior illustrated below:

```python
#+BEGIN_SRC python
# Run NH3 NEB calculations
from jasp import *
from ase.neb import NEB

with jasp('molecules/nh3-initial') as calc:
    atoms = calc.get_atoms()

with jasp('molecules/nh3-final') as calc:
    atoms2 = calc.get_atoms()

# 3 images including endpoints
images = [atoms]
images += [atoms.copy() for i in range(1)]
images += [atoms2]

neb = NEB(images)
neb.interpolate()

with jasp('molecules/nh3-neb',
          xc='PBE',
          ibrion=1,
          nsw=90,
          spring=-5, debug=logging.DEBUG,
          atoms=images) as calc:
    # Uncalculated images (should be 1)
    print calc.neb_nimages

#+END_SRC
```
#+RESULTS:
: -1

Adding + 2 is necessary to include the first and last image, and give the correct number of images in the band. Now it gives the correct result.

#+RESULTS:
: 1

I also included a minor change to only set the default functional when both 'gga' and 'xc' are missing.

Prateek