### PR TITLE
Minor bug corrections and an update to get_required_memory()

### DIFF
--- a/jasp/jasp.py
+++ b/jasp/jasp.py
@@ -408,9 +408,10 @@ def Jasp(debug=None,
     calc.kwargs = kwargs
     calc.set(**kwargs)
 
-    # create a METADATA file if it does not exist and we are not an NEB.
+    # create a METADATA file if it does not exist and not a NEB.
     if ((not os.path.exists('METADATA'))
-         and calc.int_params.get('images', None) is None):
+        and calc.int_params.get('images', None) is None
+        and (not calc.is_neb())):
         calc.create_metadata()
 
 # ** Check if beef is used

--- a/jasp/jasp_extensions.py
+++ b/jasp/jasp_extensions.py
@@ -1057,17 +1057,23 @@ def get_required_memory(self):
             for f in files:
                 os.unlink(f)
 
-    # Each node will require the memory read from the OUTCAR
+    # One node will require the memory read from the OUTCAR
     nodes = JASPRC['queue.nodes']
     ppn = JASPRC['queue.ppn']
 
     # Return an integer
     import math
-    total_memory = int(math.ceil(nodes * ppn * memory))
+    # From experience, there is a loss of about 10% efficiency in
+    # memory per node used.
+    ratio = 1.0 / float((ppn + nodes))
+    eff_factor = 1 + (0.10 / float(ratio))
+
+    # Rounded up to the nearest GB
+    total_memory = int(math.ceil(eff_factor * float(memory)))
 
     JASPRC['queue.mem'] = '{0}GB'.format(total_memory)
 
-    # return the memory as read from the OUTCAR
+    # Return the memory as read from the OUTCAR
     return memory
 
 Vasp.get_required_memory = get_required_memory

--- a/jasp/jasp_extensions.py
+++ b/jasp/jasp_extensions.py
@@ -1454,3 +1454,20 @@ def get_property(self, name, atoms=None, allow_calculation=True):
         raise NotImplementedError
 
 Vasp.get_property = get_property
+
+
+def is_neb(self):
+    """There is limited support for NEB calculations in JASP.
+
+    This function parses the OUTCAR for NEB dependent phrase:
+    ' CHAIN: Running the NEB\n' and returns True if it is found.
+
+    """
+
+    if os.path.exists('OUTCAR'):
+        with open('OUTCAR', 'r') as f:
+            lines = f.readlines()
+            if ' CHAIN: Running the NEB\n' in lines:
+                return True
+
+Vasp.is_neb = is_neb


### PR DESCRIPTION
Three minor updates are included:
1. NEB identifier function to correct minor bug in jasp.py
2. Update to get_required_memory() changing efficiency factor from 100 to 10 percent.
3. Minor indentation fix and additional directory feedback for the exception handler.
   -- This includes checks for hidden files now (A lot of my stdout files are not assigned a name and are thus recorded as the extension only, which linux interprets as a hidden file since it begins with '.')
   -- stdout file is no longer removed by default (glob checks for stdout which matches the current jobid number, making reading an old stdout highly unlikely)
